### PR TITLE
Add deleted field to primary key of history table

### DIFF
--- a/src/table.cpp
+++ b/src/table.cpp
@@ -211,7 +211,7 @@ std::string Table::sql_primary_key() const {
     }
     primary_keys += "id, ";
     if (opts.with_history) {
-        primary_keys += "version, ";
+        primary_keys += "version, deleted, ";
     }
     primary_keys.resize(primary_keys.size() - 2);
 


### PR DESCRIPTION
OSM data the version of object does not change on deletion.
So the primary key of changes should be `objtype, id, version, deleted` and not just `objtype, id, version`.